### PR TITLE
Pass values to the function using HTTP headers / EnvVar

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,9 @@
 # Fn HotWrap tool 
 
-HotWrap is a beta tool that lets you create "Hot" Fn functions based on conventional unix command line tools 
-(like shell commands or anything else you can invoke in a terminal) while also taking advantage of Fn's streaming event model inside your container.
+HotWrap is a beta tool that lets you create "Hot" Fn functions based on conventional unix command line tools (like shell commands or anything else you can invoke in a terminal) while also taking advantage of Fn's streaming event model inside your container.
  
 
-Hot wrap implements the Fn FDK contract via a command wrapper `hotwrap` this command wrapper then invokes a command for each event your function receives. 
+HotWrap implements the Fn FDK contract via a command wrapper `hotwrap` this command wrapper then invokes a command for each event your function receives. 
 
 HotWrap sends the body of incoming events to your command via STDIN and reads the response from STDOUT 
 
@@ -12,7 +11,7 @@ HotWrap sends the body of incoming events to your command via STDIN and reads th
 
 
 
-Hotwrap works best if you use a `docker` type function: 
+HotWrap works best if you use a `docker` type function: 
 
 
 suppose you have a Dockerfile for a command that works on the CLI: 
@@ -27,11 +26,11 @@ COMMAND /usr/bin/wc -l
 
 
 
-Add Hotwrap to your container as follows: 
+Add HotWrap to your container as follows: 
 
 Dockerfile:
 ```
-# Pull the hotwrap container  as a build dependency 
+# Pull the HotWrap container  as a build dependency 
 FROM fnproject/hotwrap:latest as hotwrap
 
 ## Start of your normal docker file 
@@ -62,5 +61,19 @@ echo $'some\nlines\nof\ntext' | fn invoke hotdemo example
 4
 ```
  
+You can pass value to the application using HTTP headers. 
 
-Hotwrap is a portable  statically linked binary that should work in any linux container. 
+```bash
+
+curl -H "abc:123" -H "xyz:456" http://localhost:8080/t/app/func
+
+# The function will be able to consume those values by using the correspsonding environment variables
+# FN_HEADER_Abc=123
+# FN_HEADER_Xyz=456
+
+```
+
+
+
+
+Hotwrap is a portable statically linked binary that should work in any linux container. 

--- a/hotwrap.go
+++ b/hotwrap.go
@@ -51,7 +51,7 @@ func withError(execName string, execArgs []string) fdk.HandlerFunc {
 func runExec(ctx context.Context, execCMDwithArgs string, in io.Reader, out io.Writer) error {
 	log.Println(execCMDwithArgs)
 	fctx := fdk.GetContext(ctx)
-	hdr := fctx.Header() //dd
+	hdr := fctx.Header()
 	defer timeTrack(time.Now(), fmt.Sprintf("run-exec-%v", fctx.CallID()))
 	cancel := make(chan os.Signal, 3)
 	signal.Notify(cancel, os.Interrupt)


### PR DESCRIPTION
Example: `curl -H "abc:123" -H "xyz:456" http://localhost:8080/t/app/func` will set the `FN_HEADER_Abc=123` and `FN_HEADER_Xyz=456` EnvVar in the function container.

This is needed for one of the Flow102 example.