### PR TITLE
Use from:scratch for base image, reduces hotwrap images size by several MB

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,6 @@ ADD . /go/src/func
 WORKDIR /go/src/func
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -installsuffix cgo -ldflags="-w -s" -o  /hotwrap
 
-FROM fnproject/go
+FROM scratch
 
 COPY --from=build-stage /hotwrap /hotwrap


### PR DESCRIPTION
This reduces the distribution image of hotwrap by several MB  by changing it to be from:scratch 